### PR TITLE
added script to add silence intervals

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,25 @@
 # SrtToTextgrid
 Python script to convert .srt subtitle files to Praat .textgrid files. It's general enough that it *may* work on other types of files like .sub or .sbv, but please be cautious.
 
-Written in Python 2.7.3, may not work in Python 3. 
+This was originally written in Python 2.7.3, but it also works in Python 3. 
 
 Example file is a .srt file based on a Youtube transcription of Katie Bell's keynote at a 2015 meeting of the New Zealand Python User Group. Url: https://www.youtube.com/watch?v=dj9RR4BSqvM It's almost an hour, so the audio is really too big to upload. 
+
+# Usage
+
+Before you run the main SRT-to-TextGrid converter, you may need to clean up the SRT file. Sometimes the SRT may not have dedicated intervals for silences. Praat needs those to be explicit.  The example SRT file `input-SRT-file.srt`  has this problem. To create those silent intervals, run the following command:
+
+`python3 SilentIntervalSRT.py $input-SRT-file.srt $output-SRT-file.srt`
+
+Replace the variables $input-SRT-file.srt` and `$output-SRT-file.srt` with your files. 
+
+You can then run the main script that will convert the SRT into a TextGrid. Try experimenting with either the original SRT or the cleaned up SRT:
+
+`python3 SrtToTextgrid.py $output-SRT-file.srt $output-TextGrid-file.TextGrid`
+
+`python3 SrtToTextgrid.py $input-SRT-file.srt $output-TextGrid-file.TextGrid`
+
+Replace the variables $input-SRT-file.srt`, `$output-SRT-file.srt`, and $output-TextGrid-file.TextGrid` with your files. 
+
+
+Note: The older version of `SrtToTextgrid.py' required no milliseconds in the SRT, like in the SRT file `keynote-katie-bell-how-python-works-as-a-teaching-language_en.srt`. But the current version requires milliseconds in the SRT. This can be fixed in the future.

--- a/SilentIntervalSRT.py
+++ b/SilentIntervalSRT.py
@@ -3,6 +3,7 @@
 #     * cleaning up quotation symbols because those cause trouble for Praat
 #     * remove consecutive blank lines
 #     * make the interval numbers incremently increase from 1
+#     * find timing errors
 # Made by Hossep Dolatian (github.com/jhdeov/)
 
 import codecs
@@ -16,7 +17,7 @@ outFile = sys.argv[2] # "srtOutput.srt"
 print("Useful debugging info is printed into the message.log")
 # The printing code was taken from https://stackoverflow.com/a/2513511
 old_stdout = sys.stdout
-log_file = open("message.log","w")
+log_file = open(inFile+".message.log","w")
 sys.stdout = log_file
 
 
@@ -108,12 +109,31 @@ with codecs.open(inFile, 'r', 'utf-8') as iFile:
         currentInterval = srtInterval(tempIndex,tempTime,tempContent)
         print("Created the following interval",currentInterval)
         srtintervals.append(currentInterval)
-        print("The list currently has the following intervals:")
-        for i in srtintervals:
-            print(i)
 
-        print("Done with creating the list")
 
+print("Done with creating the list")
+print("The list currently has the following intervals:")
+for i in srtintervals:
+    print(i)
+
+print("")
+
+# Now we check if there any conflicting times, like if interval A precedes interval B,
+# but A's endtime is after B's starttime
+foundTimingError = False
+for i in range(len(srtintervals)-1):
+    currentInterval = srtintervals[i]
+    nextInterval = srtintervals[i+1]
+    if currentInterval.endTime > nextInterval.startTime:
+        print("Error, the following two consecutive intervals have contradictory times")
+        print("Interval A:")
+        print(currentInterval)
+        print("Interval B")
+        print(nextInterval)
+        print("Cannot create cleaned up SRT until this error is manually solved in the original SRT")
+        foundTimingError = True
+        print("")
+if foundTimingError: quit()
 print("")
 
 # Now we clean up the file by adding silences

--- a/SilentIntervalSRT.py
+++ b/SilentIntervalSRT.py
@@ -1,10 +1,13 @@
 # Given an SRT, find any unmarked silent intervals and add them to the SRT
-# It also does some other preprocessing steps such as cleaning up quotation symbols because
-# those cause trouble for Praat
+# It also does some other preprocessing steps:
+#     * cleaning up quotation symbols because those cause trouble for Praat
+#     * remove consecutive blank lines
+#     * make the interval numbers incremently increase from 1
 # Made by Hossep Dolatian (github.com/jhdeov/)
 
 import codecs
 import sys
+import re
 
 # Input and output files as arguments
 inFile= sys.argv[1] # "srtInput.srt"
@@ -69,6 +72,17 @@ with codecs.open(inFile, 'r', 'utf-8') as iFile:
     # the input file must end in an empty new line. we add it in case it's absent
     if lines[-1] is not "":
         lines.append("")
+
+    # Will remove any consecutive blank lines, if present
+    linesTemp = []
+    for i in range(len(lines) - 1):
+        if lines[i] == '' and lines[i + 1] == '':
+            print(f'There was a blank line at index {i} before another blank line. It was removed ')
+        else:
+            linesTemp.append(lines[i])
+    linesTemp.append(lines[-1])
+    lines = linesTemp
+
     lines[0] = lines[0].replace('\ufeff', "")
     lineCounter = 0
     while lineCounter < len(lines):

--- a/SilentIntervalSRT.py
+++ b/SilentIntervalSRT.py
@@ -1,4 +1,6 @@
 # Given an SRT, find any unmarked silent intervals and add them to the SRT
+# It also does some other preprocessing steps such as cleaning up quotation symbols because
+# those cause trouble for Praat
 # Made by Hossep Dolatian (github.com/jhdeov/)
 
 import codecs
@@ -22,7 +24,10 @@ class srtInterval:
         self.number= number[:]
         self.range = range[:]
         self.startTime, self.endTime = range[:].split(" --> ")
-        self.content= content
+
+        # If the content of the SRT has a quotation symbol ", then that is changed to ""
+        # This is because Praat TextGrids are sensitive to such symbols
+        self.content= content.replace('"', '""')
     def __str__(self):
         return "index: "+str(self.number) + "\ntimes: " + str(self.range) +"\ncontent: " + self.content
 
@@ -98,9 +103,11 @@ with codecs.open(inFile, 'r', 'utf-8') as iFile:
 print("")
 
 # Now we clean up the file by adding silences
-
-# add silent intervals between SRT intervals
-for i in range(len(srtintervals)-1):
+# Because the list of intervals will grow as we add silences, we have to continously
+# check the list length
+strIntervalsCounter = 0
+while strIntervalsCounter < len(srtintervals)-1:
+    i = strIntervalsCounter
     currentInterval = srtintervals[i]
     nextInterval = srtintervals[i+1]
     if currentInterval.endTime == nextInterval.startTime:
@@ -116,6 +123,8 @@ for i in range(len(srtintervals)-1):
         print("We created a silence new interval")
         print(newInterval)
         srtintervals.insert(i+1, newInterval)
+
+    strIntervalsCounter+= 1
 
 print("")
 

--- a/SilentIntervalSRT.py
+++ b/SilentIntervalSRT.py
@@ -1,0 +1,164 @@
+# Given an SRT, find any unmarked silent intervals and add them to the SRT
+# Made by Hossep Dolatian (github.com/jhdeov/)
+
+import codecs
+import sys
+
+# Input and output files as arguments
+inFile= sys.argv[1] # "srtInput.srt"
+outFile = sys.argv[2] # "srtOutput.srt"
+
+print("Useful debugging info is printed into the message.log")
+# The printing code was taken from https://stackoverflow.com/a/2513511
+old_stdout = sys.stdout
+log_file = open("message.log","w")
+sys.stdout = log_file
+
+
+
+# define a class for intervals based on the basic template for an SRT interval
+class srtInterval:
+    def __init__(self,number,range,content):
+        self.number= number[:]
+        self.range = range[:]
+        self.startTime, self.endTime = range[:].split(" --> ")
+        self.content= content
+    def __str__(self):
+        return "index: "+str(self.number) + "\ntimes: " + str(self.range) +"\ncontent: " + self.content
+
+# creates an interval between two pre-existing SRT intervals
+def createMissingInterval(currentInterval,nextInterval):
+    newNumber= currentInterval.number + ".5"
+    newRange = currentInterval.endTime + " --> " + nextInterval.startTime
+    newContent = "[Silence]"
+    newInterval = srtInterval(newNumber,newRange,newContent)
+    return newInterval
+
+# updates the number indexes the SRT intervals in the list. This is needed if we had to insert an interval
+# note that the list is forced to start with an index 1. I don't know if this is bad
+def updateIntervals(srtintervals):
+    for i in range(len(srtintervals)):
+        srtintervals[i].number= str(i+1)
+    return srtintervals
+# create a silent interval at the beginning of the file, if needed
+def createInitialSilence(endTime):
+    newRange = "00:00:00,000 --> " + endTime
+    newInterval = srtInterval("0", newRange, "[Silence]")
+    return newInterval
+
+# with codecs.open(inFile, 'r', 'utf-8') as i:
+#     with codecs.open(outFile, 'w', 'utf-8') as o:
+
+
+##################################
+# Will now read the SRT input file and start to cleanup
+
+# this boolean will be used to check if we had to insert silence intervals
+insertedSilences= False
+
+srtintervals = []
+
+# First we read the file and turn it into a list of SRTs
+with codecs.open(inFile, 'r', 'utf-8') as iFile:
+    lines = iFile.read().splitlines()
+    # the input file must end in an empty new line. we add it in case it's absent
+    if lines[-1] is not "":
+        lines.append("")
+    lines[0] = lines[0].replace('\ufeff', "")
+    lineCounter = 0
+    while lineCounter < len(lines):
+        print(f"Currently working on line number {lineCounter} with content {lines[lineCounter]}")
+        tempIndex = lines[lineCounter]
+        lineCounter+=1
+        tempTime = lines[lineCounter]
+        lineCounter += 1
+        tempContent = lines[lineCounter]
+        lineCounter += 1
+        print("\tCurrently on line ",lines[lineCounter])
+        seeNewLine= len(lines[lineCounter])<1
+        print("\tLength of this line: ", len(lines[lineCounter]))
+        print("\tIs the line empty?: ",seeNewLine)
+        while not seeNewLine:
+            tempContent = tempContent + "\n" + lines[lineCounter]
+            print("\tContent of the current line:", tempContent)
+            lineCounter += 1
+            print("\tLineCounter:",lineCounter)
+            seeNewLine= len(lines[lineCounter])<1
+        lineCounter += 1
+
+        currentInterval = srtInterval(tempIndex,tempTime,tempContent)
+        print("Created the following interval",currentInterval)
+        srtintervals.append(currentInterval)
+        print("The list currently has the following intervals:")
+        for i in srtintervals:
+            print(i)
+
+        print("Done with creating the list")
+
+print("")
+
+# Now we clean up the file by adding silences
+
+# add silent intervals between SRT intervals
+for i in range(len(srtintervals)-1):
+    currentInterval = srtintervals[i]
+    nextInterval = srtintervals[i+1]
+    if currentInterval.endTime == nextInterval.startTime:
+        print("There is no missing interval between the following two intervals")
+        print(currentInterval)
+        print(nextInterval)
+    else:
+        insertedSilences = True
+        print("There is a missing interval between the following two intervals")
+        print(currentInterval)
+        print(nextInterval)
+        newInterval = createMissingInterval(currentInterval,nextInterval)
+        print("We created a silence new interval")
+        print(newInterval)
+        srtintervals.insert(i+1, newInterval)
+
+print("")
+
+print("The list currently:")
+for i in srtintervals:
+    print(i)
+
+print("")
+
+# check if need to add an initial silence
+print("Check if need to add initial silence")
+needInitialSilence= False
+if srtintervals[0].startTime is not "00:00:00,000":
+    print("There is a missing initial silence:",srtintervals[0].startTime)
+    newInterval = createInitialSilence(srtintervals[0].startTime)
+    print("here's new interval")
+    print(newInterval)
+    srtintervals.insert(0, newInterval)
+else:
+    print("There is no missing initial silence:",srtintervals[0].startTime)
+
+print("")
+
+print("The list currently:")
+for i in srtintervals:
+    print(i)
+
+# updates the interval indexes in the list, if needed
+print("We will update the list with new indexes")
+srtintervals = updateIntervals(srtintervals)
+
+print("")
+
+print("The list currently:")
+for i in srtintervals:
+    print(i)
+
+with codecs.open(outFile, 'w', 'utf-8') as o:
+    for line in srtintervals:
+        o.writelines(line.number + '\n')
+        o.writelines(line.range + '\n')
+        o.writelines(line.content + '\n\n')
+
+
+sys.stdout = old_stdout
+log_file.close()

--- a/SrtToTextgrid.py
+++ b/SrtToTextgrid.py
@@ -54,7 +54,8 @@ mydates = [ datetime.datetime.strptime(listOfTimes[x], "%H:%M:%S,%f").time() for
 milliseconds = numpy.array([x.microsecond for x in mydates]) / 1000000
 seconds = numpy.array([x.second for x in mydates])
 minutes = numpy.array([x.minute for x in mydates]) * 60
-times = milliseconds + seconds + minutes # this is a list of all times in seconds 
+hours = numpy.array([x.hour for x in mydates]) * 60 * 60
+times = milliseconds + seconds + minutes + hours # this is a list of all times in seconds
 numberOfIntervals = times.size//2
 
 #ok, now that we have a list of times, we can figure out the max time and start by creating the preamble for our .textgrid

--- a/SrtToTextgrid.py
+++ b/SrtToTextgrid.py
@@ -3,6 +3,7 @@
 #
 # written by Rachael Tatman, please rctatman@uw.edu with any problems.
 # Additional work by Caluã Pataca (github.com/caluap) 
+# Turned into command line by Hossep Dolatian (github.com/jhdeov/)
 
 # import
 import datetime
@@ -11,12 +12,14 @@ import numpy
 import string
 from itertools import groupby
 
+import sys # to get command line arguments
+
 from string import digits
 from collections import namedtuple
 
-# it would be nice to ask user for file name and name for converted file from command line
-input_file_path = "keynote-katie-bell-how-python-works-as-a-teaching-language_en.srt" # put the name of the file you'd like converted here
-output_file_path = "output_katie.textgrid" # put what you'd like your output file to be called here
+# Input and output files as arguments
+input_file_path= sys.argv[1] # "keynote-katie-bell-how-python-works-as-a-teaching-language_en.srt" # put the name of the file you'd like converted here
+output_file_path = sys.argv[2] # "output_katie.textgrid" # put what you'd like your output file to be called here
 
 # open .srt file
 

--- a/srtInput.srt
+++ b/srtInput.srt
@@ -1,0 +1,8 @@
+96
+00:07:08,569 --> 00:07:11,209
+I am an igloo
+- and I'm on a new line
+
+97
+00:07:11,309 --> 00:07:16,660
+And the SRT is working


### PR DESCRIPTION
Hi
Thanks for making this super useful script. I found that the script has problems with reading SRTs that didn't mark silence intervals -- which apparently is also a problem in other [scripts](https://github.com/patrickschu/textgrid-convert/issues/44). I fixed it by making my own add-on to your thing, and I also made it a command line version. 

Note that your original code required that the SRT didn't have milliseconds, but the update from Calua added milliseconds (and my SRT files also have milliseconds). I don't know if `contemporary` SRT files in general always have milliseconds now :/